### PR TITLE
chore: update authenticate_request usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,12 @@ Use the [authenticate_request](https://github.com/clerk/clerk-sdk-python/blob/ma
 import os
 import httpx
 from clerk_backend_api import Clerk
-from clerk_backend_api.jwks_helpers import AuthenticateRequestOptions
+from clerk_backend_api.jwks_helpers import authenticate_request, AuthenticateRequestOptions
 
 def is_signed_in(request: httpx.Request):
     sdk = Clerk(bearer_auth=os.getenv('CLERK_SECRET_KEY'))
-    request_state = sdk.authenticate_request(
+    request_state = authenticate_request(
+        sdk,
         request,
         AuthenticateRequestOptions(
             authorized_parties=['https://example.com']


### PR DESCRIPTION
We received feedback that using the SDK client's dynamically-assigned `authenticate_request` method was providing users with intellisense errors. This update to the usage snippet reflects a method of using this custom function in a way that prevents intellisense issues. 